### PR TITLE
fix: Fix broken action early-returns

### DIFF
--- a/src/actions/build_call_from_abi.ts
+++ b/src/actions/build_call_from_abi.ts
@@ -158,7 +158,7 @@ const action = async (
         messageBlocks.push(slackBuilder.buildSimpleSlackHeaderMsg(`:x: Error: ${error}`))
     }
 
-    return [action, returnValue, messageBlocks, buttons]
+    return [actionObject, returnValue, messageBlocks, buttons]
 }
 
 export default action

--- a/src/actions/query_all_events.ts
+++ b/src/actions/query_all_events.ts
@@ -48,7 +48,7 @@ const action = async (
                     messageBlocks.push(
                         slackBuilder.buildSimpleSectionMsg('', `:x: Error: Contract instance or provider not found`)
                     )
-                    return [action, returnValue, messageBlocks, buttons]
+                    return [actionObject, returnValue, messageBlocks, buttons]
                 }
 
                 let startBlock = 0

--- a/src/actions/send_call_from_abi.ts
+++ b/src/actions/send_call_from_abi.ts
@@ -35,7 +35,7 @@ const action = async (
 
             if (contractInstance === undefined) {
                 messageBlocks.push(slackBuilder.buildSimpleSectionMsg('', `:x: Error: Contract instance not found`))
-                return [action, returnValue, messageBlocks, buttons]
+                return [actionObject, returnValue, messageBlocks, buttons]
             }
 
             messageBlocks.push(
@@ -691,7 +691,7 @@ const action = async (
         messageBlocks.push(slackBuilder.buildSimpleSlackHeaderMsg(`:x: Error: ${error}`))
     }
 
-    return [action, returnValue, messageBlocks, buttons]
+    return [actionObject, returnValue, messageBlocks, buttons]
 }
 
 export default action


### PR DESCRIPTION
## Summary

Three action handlers returned `[action, returnValue, messageBlocks, buttons]` from error/early-return paths, where `action` is the wrapping function itself rather than the local `actionObject` state. The caller's loop destructures the first tuple element as the actionObject to thread into the next iteration, so handing back the function reference corrupted loop state.

## Fix

Swap the first tuple element to `actionObject` in the broken returns:

- `src/actions/query_all_events.ts:51` — contract-instance / provider not found
- `src/actions/send_call_from_abi.ts:38` — contract instance not found
- `src/actions/send_call_from_abi.ts:694` — final return
- `src/actions/build_call_from_abi.ts:161` — final return

The final return in `query_all_events.ts:233` already returned `actionObject` and was left alone, so that file is now consistent end-to-end.