### PR TITLE
fix: pass dBDetails (not faunaDbToken) to settings retrievers

### DIFF
--- a/src/actions/settings_abis.ts
+++ b/src/actions/settings_abis.ts
@@ -14,7 +14,7 @@ const action = async (
         messageBlocks.push(slackBuilder.buildSimpleSlackHeaderMsg(`Current active abis:`))
 
         const userSettings = await retrieveUserSettings(
-            actionObject.faunaDbToken,
+            actionObject.dBDetails,
             parsedBody.user.id,
             parsedBody.team.id
         )

--- a/src/actions/settings_apiKeys.ts
+++ b/src/actions/settings_apiKeys.ts
@@ -14,7 +14,7 @@ const action = async (
         messageBlocks.push(slackBuilder.buildSimpleSlackHeaderMsg(`Current active apiKeys:`))
 
         const userSettings = await retrieveUserSettings(
-            actionObject.faunaDbToken,
+            actionObject.dBDetails,
             parsedBody.user.id,
             parsedBody.team.id
         )

--- a/src/actions/settings_app.ts
+++ b/src/actions/settings_app.ts
@@ -12,7 +12,7 @@ const action = async (
     console.log('settings_app')
     try {
         messageBlocks.push(slackBuilder.buildSimpleSlackHeaderMsg(`Team Settings:`))
-        const teamSettings = await retrieveTeamSettings(actionObject.faunaDbToken, parsedBody.team.id)
+        const teamSettings = await retrieveTeamSettings(actionObject.dBDetails, parsedBody.team.id)
         let commandList = ''
         let contractList = ''
         let networkList = ''

--- a/src/actions/settings_commands.ts
+++ b/src/actions/settings_commands.ts
@@ -13,7 +13,7 @@ const action = async (
     try {
         messageBlocks.push(slackBuilder.buildSimpleSlackHeaderMsg(`Current active commands:`))
 
-        const teamSettings = await retrieveTeamSettings(actionObject.faunaDbToken, parsedBody.team.id)
+        const teamSettings = await retrieveTeamSettings(actionObject.dBDetails, parsedBody.team.id)
         let commandList = ''
         if (teamSettings && teamSettings.commands) {
             const { commands } = teamSettings

--- a/src/actions/settings_contracts.ts
+++ b/src/actions/settings_contracts.ts
@@ -14,7 +14,7 @@ const action = async (
         messageBlocks.push(slackBuilder.buildSimpleSlackHeaderMsg(`Current active contracts:`))
 
         const userSettings = await retrieveUserSettings(
-            actionObject.faunaDbToken,
+            actionObject.dBDetails,
             parsedBody.user.id,
             parsedBody.team.id
         )

--- a/src/actions/settings_networks.ts
+++ b/src/actions/settings_networks.ts
@@ -14,7 +14,7 @@ const action = async (
         messageBlocks.push(slackBuilder.buildSimpleSlackHeaderMsg(`Current active networks:`))
 
         const userSettings = await retrieveUserSettings(
-            actionObject.faunaDbToken,
+            actionObject.dBDetails,
             parsedBody.user.id,
             parsedBody.team.id
         )

--- a/src/actions/settings_signers.ts
+++ b/src/actions/settings_signers.ts
@@ -14,7 +14,7 @@ const action = async (
         messageBlocks.push(slackBuilder.buildSimpleSlackHeaderMsg(`Current active signers:`))
 
         const userSettings = await retrieveUserSettings(
-            actionObject.faunaDbToken,
+            actionObject.dBDetails,
             parsedBody.user.id,
             parsedBody.team.id
         )


### PR DESCRIPTION
## Summary

`retrieveUserSettings` and `retrieveTeamSettings` expect a `TDBDetails` (`{db, token}`), but several settings actions were still passing `actionObject.faunaDbToken` (a bare token string). The helpers then treated the string as the `dBDetails` object, so the `dBDetails.db` / `dBDetails.token` lookups failed and the actions silently never loaded Fauna or Mongo settings.

## Fix

Align the remaining settings actions with `src/actions/settings.ts:15`, which already passes `actionObject.dBDetails`:

- `src/actions/settings_abis.ts:17`
- `src/actions/settings_apiKeys.ts:17`
- `src/actions/settings_app.ts:15`
- `src/actions/settings_commands.ts:16`
- `src/actions/settings_contracts.ts:17`
- `src/actions/settings_networks.ts:17`
- `src/actions/settings_signers.ts:17`

All seven now pass `actionObject.dBDetails` instead of `actionObject.faunaDbToken`. `actionObject.dBDetails` is injected in `slackUtils/slackEndpoint.ts:173` alongside the other shared fields.

## Out of scope

`settings_save.ts` and `send_call_from_abi.ts` still reference `actionObject.faunaDbToken`, but those usages pass the value directly to `fauna.queryTermByFaunaIndexes(...)` (a string-typed call) inside `if (actionObject.dBDetails.db === 'fauna')` blocks. That's a different naming-cleanup issue (use `actionObject.dBDetails.token`), not the same retrieval-helper bug — left untouched to keep this fix focused.

## Verification

`npx tsc --project tsconfig.json --noEmit` passes.