### PR TITLE
feat: replace faunaDB with postgres/neonDB

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,8 +4,6 @@
     "naumovs.color-highlight",
     "anseki.vscode-color",
     "dbaeumer.vscode-eslint",
-    "fauna.fauna",
-    "fauna.faunadb",
     "eamodio.gitlens",
     "wix.glean",
     "esbenp.prettier-vscode",

--- a/README.md
+++ b/README.md
@@ -53,6 +53,48 @@ import  { slackUtils, slackBuilder, actions } from 'slack-utility'
 const { slackUtils, slackBuilder, actions } = require('slack-utility');
 ```
 
+### Database backends
+
+Settings and queued transactions are persisted via a `dBDetails` object passed to `slackEndpoint`. Two backends are supported:
+
+- `mongoDB` — MongoDB connection string as `token`, persisted via `mongoose`.
+- `postgresDB` — Postgres connection string (Neon-compatible) as `token`, persisted via `@neondatabase/serverless`.
+
+The `dbType` value in your `localSettings` selects which one to use. Required SQL schema when using `postgresDB`:
+
+```sql
+CREATE TABLE IF NOT EXISTS settings (
+    slack_team_user_id TEXT PRIMARY KEY,
+    slack_user_id      TEXT NULL,
+    slack_team_id      TEXT NOT NULL,
+    settings           JSONB NOT NULL,
+    created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at         TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS transactions (
+    id                   BIGSERIAL PRIMARY KEY,
+    tx_id                TEXT NOT NULL,
+    chain_id_and_tx_id   TEXT NOT NULL UNIQUE,
+    tx_status            TEXT NOT NULL DEFAULT 'pending-signing',
+    slack_user_id        TEXT NOT NULL,
+    slack_channel_id     TEXT NOT NULL,
+    slack_team_id        TEXT NOT NULL,
+    selected_environment TEXT,
+    selected_contract    TEXT,
+    chain_id             TEXT NOT NULL,
+    chain_name           TEXT,
+    contract_name        TEXT,
+    contract_address     TEXT,
+    method               TEXT,
+    params               JSONB NOT NULL DEFAULT '[]'::jsonb,
+    value                TEXT,
+    gas_limit            TEXT,
+    created_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at           TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+```
+
 ### Actions
 
 - `addressBook` : Show all the contract available on the selected network

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "0.1.33",
             "license": "MIT",
             "dependencies": {
+                "@neondatabase/serverless": "^1.1.0",
                 "@slack/web-api": "^8.0.0",
                 "ethers": "^6.0.0",
                 "mongoose": "^9.0.0",
@@ -70,6 +71,15 @@
             "integrity": "sha512-QAfAMwNgnYxZ2C6D1HgeP7Gc4i/uvJRim415PCIL9ptRxWMNbWeLBYb2/9R4pGKny/s1FVu2JA2cxCUBUOggrA==",
             "dependencies": {
                 "sparse-bitfield": "^3.0.3"
+            }
+        },
+        "node_modules/@neondatabase/serverless": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@neondatabase/serverless/-/serverless-1.1.0.tgz",
+            "integrity": "sha512-r3ZZhRjEcfEdKIZnoB1RusNgvHuaBRqfCzV4Gi+5A9yUX0S4HTws/ASWqt13wL4y4I+0rqsWGdA2w7EQXHi3+Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=19.0.0"
             }
         },
         "node_modules/@noble/curves": {
@@ -1053,6 +1063,11 @@
             "requires": {
                 "sparse-bitfield": "^3.0.3"
             }
+        },
+        "@neondatabase/serverless": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@neondatabase/serverless/-/serverless-1.1.0.tgz",
+            "integrity": "sha512-r3ZZhRjEcfEdKIZnoB1RusNgvHuaBRqfCzV4Gi+5A9yUX0S4HTws/ASWqt13wL4y4I+0rqsWGdA2w7EQXHi3+Q=="
         },
         "@noble/curves": {
             "version": "1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
             "dependencies": {
                 "@slack/web-api": "^8.0.0",
                 "ethers": "^6.0.0",
-                "faunadb-utility": "^0.2.1",
                 "mongoose": "^9.0.0",
                 "uuid": "^14.0.0"
             },
@@ -531,22 +530,6 @@
                 "node": ">=0.4.0"
             }
         },
-        "node_modules/ansi-align": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
-            "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
-            "dependencies": {
-                "string-width": "^4.1.0"
-            }
-        },
-        "node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/arg": {
             "version": "4.1.3",
             "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -568,110 +551,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/base64-js": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ]
-        },
-        "node_modules/boxen": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.1.2.tgz",
-            "integrity": "sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==",
-            "dependencies": {
-                "ansi-align": "^3.0.0",
-                "camelcase": "^6.2.0",
-                "chalk": "^4.1.0",
-                "cli-boxes": "^2.2.1",
-                "string-width": "^4.2.2",
-                "type-fest": "^0.20.2",
-                "widest-line": "^3.1.0",
-                "wrap-ansi": "^7.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/boxen/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/boxen/node_modules/chalk": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/boxen/node_modules/color-convert": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
-            }
-        },
-        "node_modules/boxen/node_modules/color-name": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        },
-        "node_modules/boxen/node_modules/has-flag": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/boxen/node_modules/supports-color": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/bson": {
             "version": "7.3.1",
             "resolved": "https://registry.npmjs.org/bson/-/bson-7.3.1.tgz",
@@ -680,46 +559,11 @@
                 "node": ">=20.19.0"
             }
         },
-        "node_modules/btoa-lite": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
-            "integrity": "sha512-gvW7InbIyF8AicrqWoptdW08pUxuhq8BEgowNajy9RhiE86fmGAGl+bLKo6oB8QP0CkqHLowfN0oJdKC/J6LbA=="
-        },
-        "node_modules/camelcase": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-            "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/cli-boxes": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
-            "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
-            "engines": {
-                "node": ">=6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/create-require": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
             "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
             "dev": true
-        },
-        "node_modules/cross-fetch": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
-            "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
-            "dependencies": {
-                "node-fetch": "2.6.7"
-            }
         },
         "node_modules/diff": {
             "version": "4.0.2",
@@ -729,19 +573,6 @@
             "engines": {
                 "node": ">=0.3.1"
             }
-        },
-        "node_modules/dotenv": {
-            "version": "8.6.0",
-            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
-            "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
         },
         "node_modules/ethers": {
             "version": "6.17.0",
@@ -818,117 +649,11 @@
             "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
             "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="
         },
-        "node_modules/faunadb": {
-            "version": "4.8.0",
-            "resolved": "https://registry.npmjs.org/faunadb/-/faunadb-4.8.0.tgz",
-            "integrity": "sha512-pjl5WUYQ8GqM4ESk3mv0RXfxtQMHWb92XWkxjf3nWiAkf2HVtsENfTbyGPunzw4zDbdhn9aQSSxbwahaLLDR7Q==",
-            "hasInstallScript": true,
-            "dependencies": {
-                "base64-js": "^1.2.0",
-                "boxen": "^5.0.1",
-                "btoa-lite": "^1.0.0",
-                "chalk": "^4.1.1",
-                "cross-fetch": "^3.1.5",
-                "dotenv": "^8.2.0",
-                "fn-annotate": "^1.1.3",
-                "node-abort-controller": "^3.0.1",
-                "object-assign": "^4.1.0",
-                "util-deprecate": "^1.0.2"
-            }
-        },
-        "node_modules/faunadb-utility": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/faunadb-utility/-/faunadb-utility-0.2.1.tgz",
-            "integrity": "sha512-ji/7YwTpjst7hK0QANDqsEMYCJofSbqr0GIs+ClOQedEcShpRPaVm/rJEVxMqq81GUtr116Gjl84swqAbOi8sw==",
-            "dependencies": {
-                "faunadb": "^4.8.0"
-            }
-        },
-        "node_modules/faunadb/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/faunadb/node_modules/chalk": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/faunadb/node_modules/color-convert": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
-            }
-        },
-        "node_modules/faunadb/node_modules/color-name": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        },
-        "node_modules/faunadb/node_modules/has-flag": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/faunadb/node_modules/supports-color": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/fn-annotate": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/fn-annotate/-/fn-annotate-1.2.0.tgz",
-            "integrity": "sha512-j2gv2wkRhQgkJNf1ygdca8ynP3tK+a87bowc+RG81iWTye3yKIOeAkrKYv0Kqyh8yCeSyljOk3ZFelfXUFpirA==",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/fs": {
             "version": "0.0.1-security",
             "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
             "integrity": "sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w==",
             "dev": true
-        },
-        "node_modules/is-fullwidth-code-point": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-            "engines": {
-                "node": ">=8"
-            }
         },
         "node_modules/kareem": {
             "version": "3.3.0",
@@ -1048,57 +773,6 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         },
-        "node_modules/node-abort-controller": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
-            "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ=="
-        },
-        "node_modules/node-fetch": {
-            "version": "2.6.7",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-            "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-            "dependencies": {
-                "whatwg-url": "^5.0.0"
-            },
-            "engines": {
-                "node": "4.x || >=6.0.0"
-            },
-            "peerDependencies": {
-                "encoding": "^0.1.0"
-            },
-            "peerDependenciesMeta": {
-                "encoding": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/node-fetch/node_modules/tr46": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-        },
-        "node_modules/node-fetch/node_modules/webidl-conversions": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-        },
-        "node_modules/node-fetch/node_modules/whatwg-url": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-            "dependencies": {
-                "tr46": "~0.0.3",
-                "webidl-conversions": "^3.0.0"
-            }
-        },
-        "node_modules/object-assign": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/p-finally": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -1194,30 +868,6 @@
                 "memory-pager": "^1.0.2"
             }
         },
-        "node_modules/string-width": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/tr46": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
@@ -1272,17 +922,6 @@
                 }
             }
         },
-        "node_modules/type-fest": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-            "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/typescript": {
             "version": "7.0.2",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
@@ -1322,11 +961,6 @@
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
             "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="
         },
-        "node_modules/util-deprecate": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
-        },
         "node_modules/uuid": {
             "version": "14.0.1",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
@@ -1364,63 +998,6 @@
             "engines": {
                 "node": ">=18"
             }
-        },
-        "node_modules/widest-line": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
-            "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
-            "dependencies": {
-                "string-width": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/wrap-ansi": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-            "dependencies": {
-                "ansi-styles": "^4.0.0",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-            }
-        },
-        "node_modules/wrap-ansi/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/wrap-ansi/node_modules/color-convert": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
-            }
-        },
-        "node_modules/wrap-ansi/node_modules/color-name": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "node_modules/yn": {
             "version": "3.1.1",
@@ -1725,19 +1302,6 @@
             "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
             "dev": true
         },
-        "ansi-align": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
-            "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
-            "requires": {
-                "string-width": "^4.1.0"
-            }
-        },
-        "ansi-regex": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
-        },
         "arg": {
             "version": "4.1.3",
             "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -1753,90 +1317,10 @@
                 "fs": "^0.0.1-security"
             }
         },
-        "base64-js": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
-        },
-        "boxen": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.1.2.tgz",
-            "integrity": "sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==",
-            "requires": {
-                "ansi-align": "^3.0.0",
-                "camelcase": "^6.2.0",
-                "chalk": "^4.1.0",
-                "cli-boxes": "^2.2.1",
-                "string-width": "^4.2.2",
-                "type-fest": "^0.20.2",
-                "widest-line": "^3.1.0",
-                "wrap-ansi": "^7.0.0"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "4.3.0",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-                    "requires": {
-                        "color-convert": "^2.0.1"
-                    }
-                },
-                "chalk": {
-                    "version": "4.1.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-                    "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
-                },
-                "color-convert": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-                    "requires": {
-                        "color-name": "~1.1.4"
-                    }
-                },
-                "color-name": {
-                    "version": "1.1.4",
-                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-                },
-                "has-flag": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-                },
-                "supports-color": {
-                    "version": "7.2.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-                    "requires": {
-                        "has-flag": "^4.0.0"
-                    }
-                }
-            }
-        },
         "bson": {
             "version": "7.3.1",
             "resolved": "https://registry.npmjs.org/bson/-/bson-7.3.1.tgz",
             "integrity": "sha512-h/C0qe6857pQhcSJHLfsR1uYGj98Ge3wKAD3Ed9KqH3wcVh+BM4Jq4xISD7vs9OPuT07n+q3QQVjslJ286j6ag=="
-        },
-        "btoa-lite": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
-            "integrity": "sha512-gvW7InbIyF8AicrqWoptdW08pUxuhq8BEgowNajy9RhiE86fmGAGl+bLKo6oB8QP0CkqHLowfN0oJdKC/J6LbA=="
-        },
-        "camelcase": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-            "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="
-        },
-        "cli-boxes": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
-            "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw=="
         },
         "create-require": {
             "version": "1.1.1",
@@ -1844,29 +1328,11 @@
             "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
             "dev": true
         },
-        "cross-fetch": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
-            "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
-            "requires": {
-                "node-fetch": "2.6.7"
-            }
-        },
         "diff": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
             "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
             "dev": true
-        },
-        "dotenv": {
-            "version": "8.6.0",
-            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
-            "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g=="
-        },
-        "emoji-regex": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
         },
         "ethers": {
             "version": "6.17.0",
@@ -1917,91 +1383,11 @@
             "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
             "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="
         },
-        "faunadb": {
-            "version": "4.8.0",
-            "resolved": "https://registry.npmjs.org/faunadb/-/faunadb-4.8.0.tgz",
-            "integrity": "sha512-pjl5WUYQ8GqM4ESk3mv0RXfxtQMHWb92XWkxjf3nWiAkf2HVtsENfTbyGPunzw4zDbdhn9aQSSxbwahaLLDR7Q==",
-            "requires": {
-                "base64-js": "^1.2.0",
-                "boxen": "^5.0.1",
-                "btoa-lite": "^1.0.0",
-                "chalk": "^4.1.1",
-                "cross-fetch": "^3.1.5",
-                "dotenv": "^8.2.0",
-                "fn-annotate": "^1.1.3",
-                "node-abort-controller": "^3.0.1",
-                "object-assign": "^4.1.0",
-                "util-deprecate": "^1.0.2"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "4.3.0",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-                    "requires": {
-                        "color-convert": "^2.0.1"
-                    }
-                },
-                "chalk": {
-                    "version": "4.1.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-                    "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
-                },
-                "color-convert": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-                    "requires": {
-                        "color-name": "~1.1.4"
-                    }
-                },
-                "color-name": {
-                    "version": "1.1.4",
-                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-                },
-                "has-flag": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-                },
-                "supports-color": {
-                    "version": "7.2.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-                    "requires": {
-                        "has-flag": "^4.0.0"
-                    }
-                }
-            }
-        },
-        "faunadb-utility": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/faunadb-utility/-/faunadb-utility-0.2.1.tgz",
-            "integrity": "sha512-ji/7YwTpjst7hK0QANDqsEMYCJofSbqr0GIs+ClOQedEcShpRPaVm/rJEVxMqq81GUtr116Gjl84swqAbOi8sw==",
-            "requires": {
-                "faunadb": "^4.8.0"
-            }
-        },
-        "fn-annotate": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/fn-annotate/-/fn-annotate-1.2.0.tgz",
-            "integrity": "sha512-j2gv2wkRhQgkJNf1ygdca8ynP3tK+a87bowc+RG81iWTye3yKIOeAkrKYv0Kqyh8yCeSyljOk3ZFelfXUFpirA=="
-        },
         "fs": {
             "version": "0.0.1-security",
             "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
             "integrity": "sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w==",
             "dev": true
-        },
-        "is-fullwidth-code-point": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
         },
         "kareem": {
             "version": "3.3.0",
@@ -2066,45 +1452,6 @@
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-        },
-        "node-abort-controller": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
-            "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ=="
-        },
-        "node-fetch": {
-            "version": "2.6.7",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-            "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-            "requires": {
-                "whatwg-url": "^5.0.0"
-            },
-            "dependencies": {
-                "tr46": {
-                    "version": "0.0.3",
-                    "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-                    "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-                },
-                "webidl-conversions": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-                    "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-                },
-                "whatwg-url": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-                    "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-                    "requires": {
-                        "tr46": "~0.0.3",
-                        "webidl-conversions": "^3.0.0"
-                    }
-                }
-            }
-        },
-        "object-assign": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
         },
         "p-finally": {
             "version": "1.0.0",
@@ -2173,24 +1520,6 @@
                 "memory-pager": "^1.0.2"
             }
         },
-        "string-width": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "requires": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            }
-        },
-        "strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "requires": {
-                "ansi-regex": "^5.0.1"
-            }
-        },
         "tr46": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
@@ -2219,11 +1548,6 @@
                 "v8-compile-cache-lib": "^3.0.1",
                 "yn": "3.1.1"
             }
-        },
-        "type-fest": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-            "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
         },
         "typescript": {
             "version": "7.0.2",
@@ -2258,11 +1582,6 @@
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
             "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="
         },
-        "util-deprecate": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
-        },
         "uuid": {
             "version": "14.0.1",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
@@ -2286,47 +1605,6 @@
             "requires": {
                 "tr46": "^5.1.0",
                 "webidl-conversions": "^7.0.0"
-            }
-        },
-        "widest-line": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
-            "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
-            "requires": {
-                "string-width": "^4.0.0"
-            }
-        },
-        "wrap-ansi": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-            "requires": {
-                "ansi-styles": "^4.0.0",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "4.3.0",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-                    "requires": {
-                        "color-convert": "^2.0.1"
-                    }
-                },
-                "color-convert": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-                    "requires": {
-                        "color-name": "~1.1.4"
-                    }
-                },
-                "color-name": {
-                    "version": "1.1.4",
-                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-                }
             }
         },
         "yn": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     },
     "homepage": "https://github.com/marc-aurele-besner/slack-utility#readme",
     "dependencies": {
+        "@neondatabase/serverless": "^1.1.0",
         "@slack/web-api": "^8.0.0",
         "ethers": "^6.0.0",
         "mongoose": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "dependencies": {
         "@slack/web-api": "^8.0.0",
         "ethers": "^6.0.0",
-        "faunadb-utility": "^0.2.1",
         "mongoose": "^9.0.0",
         "uuid": "^14.0.0"
     },

--- a/src/actions/send_call_from_abi.ts
+++ b/src/actions/send_call_from_abi.ts
@@ -5,6 +5,7 @@ import { v4 as uuidv4 } from 'uuid'
 import slackBuilder from '../slackBuilder'
 import slackUtils from '../slackUtils'
 import retrieveEnvironment from '../slackUtils/retrieveEnvironment'
+import getPool from '../slackUtils/pgPool'
 import { TBlockElements, TBlocks, TReturnValue } from '../types'
 
 const action = async (
@@ -604,6 +605,47 @@ const action = async (
                             try {
                                 const db = await mongoose.connect(actionObject.dBDetails.token)
                                 await db.connection.collection('transactions').insertOne(dataToAdd)
+                            } catch (e) {
+                                console.log('e', e)
+                            }
+                        }
+                        if (actionObject.dBDetails.db === 'postgres') {
+                            try {
+                                const pool = getPool(actionObject.dBDetails.token)
+                                await pool.query(
+                                    `INSERT INTO transactions (
+                                        tx_id, chain_id_and_tx_id, tx_status,
+                                        slack_user_id, slack_channel_id, slack_team_id,
+                                        selected_environment, selected_contract, chain_id,
+                                        chain_name, contract_name, contract_address,
+                                        method, params, value, gas_limit
+                                     ) VALUES (
+                                        $1, $2, $3,
+                                        $4, $5, $6,
+                                        $7, $8, $9,
+                                        $10, $11, $12,
+                                        $13, $14::jsonb, $15, $16
+                                     )`,
+                                    [
+                                        dataToAdd.txId,
+                                        dataToAdd.chainIdAndTxId,
+                                        dataToAdd.txStatus,
+                                        dataToAdd.slackUserId,
+                                        dataToAdd.slackChannelId,
+                                        dataToAdd.slackTeamId,
+                                        dataToAdd.selectedEnvironment,
+                                        dataToAdd.selectedContract,
+                                        dataToAdd.chainId,
+                                        dataToAdd.chainName,
+                                        dataToAdd.contractName,
+                                        dataToAdd.contractAddress,
+                                        dataToAdd.method,
+                                        JSON.stringify(dataToAdd.params),
+                                        dataToAdd.value,
+                                        dataToAdd.gasLimit
+                                    ]
+                                )
+                                tx = dataToAdd
                             } catch (e) {
                                 console.log('e', e)
                             }

--- a/src/actions/send_call_from_abi.ts
+++ b/src/actions/send_call_from_abi.ts
@@ -1,5 +1,4 @@
 import { toBeHex } from 'ethers'
-import fauna from 'faunadb-utility'
 import mongoose from 'mongoose'
 import { v4 as uuidv4 } from 'uuid'
 
@@ -600,17 +599,6 @@ const action = async (
                             params,
                             value: '0x00',
                             gasLimit: toBeHex(5000000)
-                        }
-                        if (actionObject.dBDetails.db === 'fauna') {
-                            try {
-                                tx = await fauna.createFaunaDocument(
-                                    actionObject.faunaDbToken,
-                                    'transactions',
-                                    dataToAdd
-                                )
-                            } catch (e) {
-                                console.log('e', e)
-                            }
                         }
                         if (actionObject.dBDetails.db === 'mongo') {
                             try {

--- a/src/actions/settings_save.ts
+++ b/src/actions/settings_save.ts
@@ -2,6 +2,7 @@ import mongoose from 'mongoose'
 
 import slackBuilder from '../slackBuilder'
 import slackUtils from '../slackUtils'
+import getPool from '../slackUtils/pgPool'
 import {
     TAbi,
     TApiKey,
@@ -122,10 +123,18 @@ const action = async (
                     slackTeamUserId: isTeam ? parsedBody.team.id : parsedBody.team.id + '_' + parsedBody.user.id
                 })
             }
+            if (actionObject.dBDetails.db === 'postgres') {
+                const pool = getPool(actionObject.dBDetails.token)
+                const { rows } = await pool.query(
+                    'SELECT settings FROM settings WHERE slack_team_user_id = $1 LIMIT 1',
+                    [isTeam ? parsedBody.team.id : parsedBody.team.id + '_' + parsedBody.user.id]
+                )
+                getDbUserSettings = rows.length > 0 ? { settings: rows[0].settings } : null
+            }
             if (values.actionType !== undefined && values.collection !== undefined && values.actionType === 'delete') {
                 if (
                     getDbUserSettings != null &&
-                    actionObject.dBDetails.db === 'mongo' &&
+                    (actionObject.dBDetails.db === 'mongo' || actionObject.dBDetails.db === 'postgres') &&
                     values.selected_option.value !== undefined
                 ) {
                     switch (values.collection) {
@@ -200,6 +209,21 @@ const action = async (
                             }
                         )
                     }
+                    if (actionObject.dBDetails.db === 'postgres') {
+                        const pool = getPool(actionObject.dBDetails.token)
+                        await pool.query(
+                            `INSERT INTO settings (slack_team_user_id, slack_user_id, slack_team_id, settings, updated_at)
+                             VALUES ($1, $2, $3, $4::jsonb, NOW())
+                             ON CONFLICT (slack_team_user_id)
+                             DO UPDATE SET settings = EXCLUDED.settings, updated_at = NOW()`,
+                            [
+                                isTeam ? parsedBody.team.id : parsedBody.team.id + '_' + parsedBody.user.id,
+                                isTeam ? null : parsedBody.user.id,
+                                parsedBody.team.id,
+                                JSON.stringify(isTeam ? teamSettings : userSettings)
+                            ]
+                        )
+                    }
                 } else messageBlocks.push(slackBuilder.buildSimpleSectionMsg('No settings found'))
             } else {
                 if (getDbUserSettings == null) {
@@ -216,6 +240,20 @@ const action = async (
                                       slackTeamUserId: parsedBody.team.id + '_' + parsedBody.user.id,
                                       settings: userSettings
                                   }
+                        )
+                    }
+                    if (actionObject.dBDetails.db === 'postgres') {
+                        const pool = getPool(actionObject.dBDetails.token)
+                        await pool.query(
+                            `INSERT INTO settings (slack_team_user_id, slack_user_id, slack_team_id, settings)
+                             VALUES ($1, $2, $3, $4::jsonb)
+                             ON CONFLICT (slack_team_user_id) DO NOTHING`,
+                            [
+                                isTeam ? parsedBody.team.id : parsedBody.team.id + '_' + parsedBody.user.id,
+                                isTeam ? null : parsedBody.user.id,
+                                parsedBody.team.id,
+                                JSON.stringify(isTeam ? teamSettings : userSettings)
+                            ]
                         )
                     }
                 } else {
@@ -283,6 +321,67 @@ const action = async (
                             }
                         )
                     }
+                    if (getDbUserSettings != null && actionObject.dBDetails.db === 'postgres') {
+                        if (getDbUserSettings.settings.commands && isTeam)
+                            teamSettings.commands = [...teamSettings.commands, ...getDbUserSettings.settings.commands]
+                        if (getDbUserSettings.settings.abis)
+                            isTeam
+                                ? (teamSettings.abis = [...teamSettings.abis, ...getDbUserSettings.settings.abis])
+                                : (userSettings.abis = [...userSettings.abis, ...getDbUserSettings.settings.abis])
+                        if (getDbUserSettings.settings.networks)
+                            isTeam
+                                ? (teamSettings.networks = [
+                                      ...teamSettings.networks,
+                                      ...getDbUserSettings.settings.networks
+                                  ])
+                                : (userSettings.networks = [
+                                      ...userSettings.networks,
+                                      ...getDbUserSettings.settings.networks
+                                  ])
+                        if (getDbUserSettings.settings.contracts)
+                            isTeam
+                                ? (teamSettings.contracts = [
+                                      ...teamSettings.contracts,
+                                      ...getDbUserSettings.settings.contracts
+                                  ])
+                                : (userSettings.contracts = [
+                                      ...userSettings.contracts,
+                                      ...getDbUserSettings.settings.contracts
+                                  ])
+                        if (getDbUserSettings.settings.apiKeys)
+                            isTeam
+                                ? (teamSettings.apiKeys = [
+                                      ...teamSettings.apiKeys,
+                                      ...getDbUserSettings.settings.apiKeys
+                                  ])
+                                : (userSettings.apiKeys = [
+                                      ...userSettings.apiKeys,
+                                      ...getDbUserSettings.settings.apiKeys
+                                  ])
+                        if (getDbUserSettings.settings.signers)
+                            isTeam
+                                ? (teamSettings.signers = [
+                                      ...teamSettings.signers,
+                                      ...getDbUserSettings.settings.signers
+                                  ])
+                                : (userSettings.signers = [
+                                      ...userSettings.signers,
+                                      ...getDbUserSettings.settings.signers
+                                  ])
+                        const pool = getPool(actionObject.dBDetails.token)
+                        await pool.query(
+                            `INSERT INTO settings (slack_team_user_id, slack_user_id, slack_team_id, settings, updated_at)
+                             VALUES ($1, $2, $3, $4::jsonb, NOW())
+                             ON CONFLICT (slack_team_user_id)
+                             DO UPDATE SET settings = EXCLUDED.settings, updated_at = NOW()`,
+                            [
+                                isTeam ? parsedBody.team.id : parsedBody.team.id + '_' + parsedBody.user.id,
+                                isTeam ? null : parsedBody.user.id,
+                                parsedBody.team.id,
+                                JSON.stringify(isTeam ? teamSettings : userSettings)
+                            ]
+                        )
+                    }
                 }
             }
         } else if (actionObject.value !== undefined) {
@@ -296,6 +395,14 @@ const action = async (
                     getDbUserSettings = await db.connection.collection('settings').findOne({
                         slackTeamUserId: parsedBody.team.id + '_' + parsedBody.user.id
                     })
+                }
+                if (actionObject.dBDetails.db === 'postgres') {
+                    const pool = getPool(actionObject.dBDetails.token)
+                    const { rows } = await pool.query(
+                        'SELECT settings FROM settings WHERE slack_team_user_id = $1 LIMIT 1',
+                        [parsedBody.team.id + '_' + parsedBody.user.id]
+                    )
+                    getDbUserSettings = rows.length > 0 ? { settings: rows[0].settings } : null
                 }
                 if (actionObject.dBDetails.db === 'mongo' && getDbUserSettings != null && getDbUserSettings.settings) {
                     const newSettings = getDbUserSettings.settings
@@ -323,6 +430,41 @@ const action = async (
                             slackTeamUserId: parsedBody.team.id + '_' + parsedBody.user.id,
                             settings: newSettings
                         }
+                    )
+                }
+                if (
+                    actionObject.dBDetails.db === 'postgres' &&
+                    getDbUserSettings != null &&
+                    getDbUserSettings.settings
+                ) {
+                    const newSettings = getDbUserSettings.settings
+                    if (subAction === 'delete_network')
+                        newSettings.networks = newSettings.networks.filter(
+                            (network: TNetwork) => network.value !== value
+                        )
+                    if (subAction === 'delete_contract')
+                        newSettings.contracts = newSettings.contracts.filter(
+                            (contract: TContract) => contract.name !== value
+                        )
+                    if (subAction === 'delete_abi')
+                        newSettings.abis = newSettings.abis.filter((contract: TAbi) => contract.name !== value)
+                    if (subAction === 'delete_apiKey')
+                        newSettings.apiKeys = newSettings.apiKeys.filter((contract: TApiKey) => contract.name !== value)
+                    if (subAction === 'delete_signer')
+                        newSettings.signers = newSettings.signers.filter((contract: TSigner) => contract.name !== value)
+
+                    const pool = getPool(actionObject.dBDetails.token)
+                    await pool.query(
+                        `INSERT INTO settings (slack_team_user_id, slack_user_id, slack_team_id, settings, updated_at)
+                         VALUES ($1, $2, $3, $4::jsonb, NOW())
+                         ON CONFLICT (slack_team_user_id)
+                         DO UPDATE SET settings = EXCLUDED.settings, updated_at = NOW()`,
+                        [
+                            parsedBody.team.id + '_' + parsedBody.user.id,
+                            parsedBody.user.id,
+                            parsedBody.team.id,
+                            JSON.stringify(newSettings)
+                        ]
                     )
                 }
                 await slackUtils.slackDeleteMessage(actionObject.slackToken, parsedBody.channel.id, originalMessage)

--- a/src/actions/settings_save.ts
+++ b/src/actions/settings_save.ts
@@ -1,4 +1,3 @@
-import fauna from 'faunadb-utility'
 import mongoose from 'mongoose'
 
 import slackBuilder from '../slackBuilder'
@@ -117,13 +116,6 @@ const action = async (
             // Check if user has settings in DB
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             let getDbUserSettings: any = null
-            if (actionObject.dBDetails.db === 'fauna') {
-                getDbUserSettings = await fauna.queryTermByFaunaIndexes(
-                    actionObject.faunaDbToken,
-                    'settings_by_slackTeamUserId',
-                    isTeam ? parsedBody.team.id : parsedBody.team.id + '_' + parsedBody.user.id
-                )
-            }
             if (actionObject.dBDetails.db === 'mongo') {
                 const db = await mongoose.connect(actionObject.dBDetails.token)
                 getDbUserSettings = await db.connection.collection('settings').findOne({
@@ -133,69 +125,63 @@ const action = async (
             if (values.actionType !== undefined && values.collection !== undefined && values.actionType === 'delete') {
                 if (
                     getDbUserSettings != null &&
-                    ((actionObject.dBDetails.db === 'fauna' && JSON.parse(getDbUserSettings.body).length > 0) ||
-                        (actionObject.dBDetails.db === 'mongo' && getDbUserSettings != null)) &&
+                    actionObject.dBDetails.db === 'mongo' &&
                     values.selected_option.value !== undefined
                 ) {
                     switch (values.collection) {
                         case 'networks':
-                            isTeam
-                                ? teamSettings.networks.filter(
-                                      (network: TNetwork) => network.value !== values.selected_option.value
-                                  )
-                                : userSettings.networks.filter(
-                                      (network: TNetwork) => network.value !== values.selected_option.value
-                                  )
+                            if (isTeam)
+                                teamSettings.networks = teamSettings.networks.filter(
+                                    (network: TNetwork) => network.value !== values.selected_option.value
+                                )
+                            else
+                                userSettings.networks = userSettings.networks.filter(
+                                    (network: TNetwork) => network.value !== values.selected_option.value
+                                )
                             break
                         case 'contracts':
-                            isTeam
-                                ? teamSettings.contracts.filter(
-                                      (contract: TContract) => contract.name !== values.selected_option.value
-                                  )
-                                : userSettings.contracts.filter(
-                                      (contract: TContract) => contract.name !== values.selected_option.value
-                                  )
+                            if (isTeam)
+                                teamSettings.contracts = teamSettings.contracts.filter(
+                                    (contract: TContract) => contract.name !== values.selected_option.value
+                                )
+                            else
+                                userSettings.contracts = userSettings.contracts.filter(
+                                    (contract: TContract) => contract.name !== values.selected_option.value
+                                )
                             break
                         case 'abis':
-                            isTeam
-                                ? teamSettings.abis.filter((abi: TAbi) => abi.name !== values.selected_option.value)
-                                : userSettings.abis.filter((abi: TAbi) => abi.name !== values.selected_option.value)
+                            if (isTeam)
+                                teamSettings.abis = teamSettings.abis.filter(
+                                    (abi: TAbi) => abi.name !== values.selected_option.value
+                                )
+                            else
+                                userSettings.abis = userSettings.abis.filter(
+                                    (abi: TAbi) => abi.name !== values.selected_option.value
+                                )
                             break
 
                         case 'apiKeys':
-                            isTeam
-                                ? teamSettings.apiKeys.filter(
-                                      (apiKey: TApiKey) => apiKey.name !== values.selected_option.value
-                                  )
-                                : userSettings.apiKeys.filter(
-                                      (apiKey: TApiKey) => apiKey.name !== values.selected_option.value
-                                  )
+                            if (isTeam)
+                                teamSettings.apiKeys = teamSettings.apiKeys.filter(
+                                    (apiKey: TApiKey) => apiKey.name !== values.selected_option.value
+                                )
+                            else
+                                userSettings.apiKeys = userSettings.apiKeys.filter(
+                                    (apiKey: TApiKey) => apiKey.name !== values.selected_option.value
+                                )
                             break
                         case 'signers':
-                            isTeam
-                                ? teamSettings.signers.filter(
-                                      (signer: TSigner) => signer.name !== values.selected_option.value
-                                  )
-                                : userSettings.signers.filter(
-                                      (signer: TSigner) => signer.name !== values.selected_option.value
-                                  )
+                            if (isTeam)
+                                teamSettings.signers = teamSettings.signers.filter(
+                                    (signer: TSigner) => signer.name !== values.selected_option.value
+                                )
+                            else
+                                userSettings.signers = userSettings.signers.filter(
+                                    (signer: TSigner) => signer.name !== values.selected_option.value
+                                )
                             break
                         default:
                             break
-                    }
-                    if (actionObject.dBDetails.db === 'fauna') {
-                        await fauna.updateFaunaDocument(
-                            actionObject.faunaDbToken,
-                            'settings',
-                            JSON.parse(getDbUserSettings.body)[0].ref['@ref'].id,
-                            {
-                                slackUserId: parsedBody.user.id,
-                                slackTeamUserId: isTeam
-                                    ? parsedBody.team.id
-                                    : parsedBody.team.id + '_' + parsedBody.user.id,
-                                settings: isTeam ? teamSettings : userSettings
-                            }
-                        )
                     }
                     if (actionObject.dBDetails.db === 'mongo') {
                         const db = await mongoose.connect(actionObject.dBDetails.token)
@@ -216,27 +202,7 @@ const action = async (
                     }
                 } else messageBlocks.push(slackBuilder.buildSimpleSectionMsg('No settings found'))
             } else {
-                if (
-                    getDbUserSettings != null &&
-                    ((actionObject.dBDetails.db === 'fauna' && JSON.parse(getDbUserSettings.body).length === 0) ||
-                        (actionObject.dBDetails.db === 'mongo' && getDbUserSettings == null))
-                ) {
-                    if (actionObject.dBDetails.db === 'fauna') {
-                        await fauna.createFaunaDocument(
-                            actionObject.faunaDbToken,
-                            'settings',
-                            isTeam
-                                ? {
-                                      slackTeamUserId: parsedBody.team.id,
-                                      settings: teamSettings
-                                  }
-                                : {
-                                      slackUserId: parsedBody.user.id,
-                                      slackTeamUserId: parsedBody.team.id + '_' + parsedBody.user.id,
-                                      settings: userSettings
-                                  }
-                        )
-                    }
+                if (getDbUserSettings == null) {
                     if (actionObject.dBDetails.db === 'mongo') {
                         const db = await mongoose.connect(actionObject.dBDetails.token)
                         await db.connection.collection('settings').insertOne(
@@ -253,75 +219,6 @@ const action = async (
                         )
                     }
                 } else {
-                    if (getDbUserSettings != null && actionObject.dBDetails.db === 'fauna') {
-                        if (JSON.parse(getDbUserSettings.body)[0].data.settings.commands && isTeam)
-                            teamSettings.commands = [
-                                ...teamSettings.commands,
-                                ...JSON.parse(getDbUserSettings.body)[0].data.settings.commands
-                            ]
-                        if (JSON.parse(getDbUserSettings.body)[0].data.settings.abis)
-                            isTeam
-                                ? (teamSettings.abis = [
-                                      ...teamSettings.abis,
-                                      ...JSON.parse(getDbUserSettings.body)[0].data.settings.abis
-                                  ])
-                                : (userSettings.abis = [
-                                      ...userSettings.abis,
-                                      ...JSON.parse(getDbUserSettings.body)[0].data.settings.abis
-                                  ])
-                        if (JSON.parse(getDbUserSettings.body)[0].data.settings.networks)
-                            isTeam
-                                ? (teamSettings.networks = [
-                                      ...teamSettings.networks,
-                                      ...JSON.parse(getDbUserSettings.body)[0].data.settings.networks
-                                  ])
-                                : (userSettings.networks = [
-                                      ...userSettings.networks,
-                                      ...JSON.parse(getDbUserSettings.body)[0].data.settings.networks
-                                  ])
-                        if (JSON.parse(getDbUserSettings.body)[0].data.settings.contracts)
-                            isTeam
-                                ? (teamSettings.contracts = [
-                                      ...teamSettings.contracts,
-                                      ...JSON.parse(getDbUserSettings.body)[0].data.settings.contracts
-                                  ])
-                                : (userSettings.contracts = [
-                                      ...userSettings.contracts,
-                                      ...JSON.parse(getDbUserSettings.body)[0].data.settings.contracts
-                                  ])
-                        if (JSON.parse(getDbUserSettings.body)[0].data.settings.apiKeys)
-                            isTeam
-                                ? (teamSettings.apiKeys = [
-                                      ...teamSettings.apiKeys,
-                                      ...JSON.parse(getDbUserSettings.body)[0].data.settings.apiKeys
-                                  ])
-                                : (userSettings.apiKeys = [
-                                      ...userSettings.apiKeys,
-                                      ...JSON.parse(getDbUserSettings.body)[0].data.settings.apiKeys
-                                  ])
-                        if (JSON.parse(getDbUserSettings.body)[0].data.settings.signers)
-                            isTeam
-                                ? (teamSettings.signers = [
-                                      ...teamSettings.signers,
-                                      ...JSON.parse(getDbUserSettings.body)[0].data.settings.signers
-                                  ])
-                                : (userSettings.signers = [
-                                      ...userSettings.signers,
-                                      ...JSON.parse(getDbUserSettings.body)[0].data.settings.signers
-                                  ])
-                        await fauna.updateFaunaDocument(
-                            actionObject.faunaDbToken,
-                            'settings',
-                            JSON.parse(getDbUserSettings.body)[0].ref['@ref'].id,
-                            {
-                                slackUserId: parsedBody.user.id,
-                                slackTeamUserId: isTeam
-                                    ? parsedBody.team.id
-                                    : parsedBody.team.id + '_' + parsedBody.user.id,
-                                settings: isTeam ? teamSettings : userSettings
-                            }
-                        )
-                    }
                     if (getDbUserSettings != null && actionObject.dBDetails.db === 'mongo') {
                         if (getDbUserSettings.body.settings.commands && isTeam)
                             teamSettings.commands = [...teamSettings.commands, ...getDbUserSettings.body.commands]
@@ -375,7 +272,7 @@ const action = async (
                                 slackUserId: parsedBody.user.id,
                                 slackTeamUserId: isTeam
                                     ? parsedBody.team.id
-                                    : parsedBody.team.id + '_' + parsedBody.user.id2
+                                    : parsedBody.team.id + '_' + parsedBody.user.id
                             },
                             {
                                 slackUserId: parsedBody.user.id,
@@ -394,45 +291,11 @@ const action = async (
                 const { subAction, value, originalMessage } = JSON.parse(actionObject.value)
                 // eslint-disable-next-line no-explicit-any
                 let getDbUserSettings: any = null
-                if (actionObject.dBDetails.db === 'fauna') {
-                    getDbUserSettings = await fauna.queryTermByFaunaIndexes(
-                        actionObject.faunaDbToken,
-                        'settings_by_slackTeamUserId',
-                        parsedBody.team.id + '_' + parsedBody.user.id
-                    )
-                }
                 if (actionObject.dBDetails.db === 'mongo') {
                     const db = await mongoose.connect(actionObject.dBDetails.token)
                     getDbUserSettings = await db.connection.collection('settings').findOne({
                         slackTeamUserId: parsedBody.team.id + '_' + parsedBody.user.id
                     })
-                }
-                if (
-                    actionObject.dBDetails.db === 'fauna' &&
-                    getDbUserSettings != null &&
-                    JSON.parse(getDbUserSettings.body).length > 0
-                ) {
-                    const newSettings = JSON.parse(getDbUserSettings.body)[0].data.settings
-                    if (subAction === 'delete_network')
-                        newSettings.networks = newSettings.networks.filter(
-                            (network: TNetwork) => network.value !== value
-                        )
-                    if (subAction === 'delete_contract')
-                        newSettings.contracts = newSettings.contracts.filter(
-                            (contract: TContract) => contract.name !== value
-                        )
-                    if (subAction === 'delete_abi')
-                        newSettings.abis = newSettings.abis.filter((contract: TAbi) => contract.name !== value)
-                    if (subAction === 'delete_apiKey')
-                        newSettings.apiKeys = newSettings.apiKeys.filter((contract: TApiKey) => contract.name !== value)
-                    if (subAction === 'delete_signer')
-                        newSettings.signers = newSettings.signers.filter((contract: TSigner) => contract.name !== value)
-                    await fauna.updateFaunaDocument(
-                        actionObject.faunaDbToken,
-                        'settings',
-                        JSON.parse(getDbUserSettings.body)[0].ref['@ref'].id,
-                        { settings: newSettings }
-                    )
                 }
                 if (actionObject.dBDetails.db === 'mongo' && getDbUserSettings != null && getDbUserSettings.settings) {
                     const newSettings = getDbUserSettings.settings

--- a/src/slackUtils/README.md
+++ b/src/slackUtils/README.md
@@ -15,7 +15,7 @@
 ```
 
 
- - [README.md](./README.md) - [actionsLoop.ts](./actionsLoop.ts) - [callerSettings.ts](./callerSettings.ts) - [commandsLoop.ts](./commandsLoop.ts) - [index.ts](./index.ts) - [retrieveEnvironment.ts](./retrieveEnvironment.ts) - [retrieveEvent.ts](./retrieveEvent.ts) - [retrieveModule.ts](./retrieveModule.ts) - [retrieveTeamSettings.ts](./retrieveTeamSettings.ts) - [retrieveUserSettings.ts](./retrieveUserSettings.ts) - [setupContractAndNetwork.ts](./setupContractAndNetwork.ts) - [setupContractNetworkAndSigner.ts](./setupContractNetworkAndSigner.ts) - [setupNetwork.ts](./setupNetwork.ts) - [slackAddPin.ts](./slackAddPin.ts) - [slackDeleteMessage.ts](./slackDeleteMessage.ts) - [slackEndpoint.ts](./slackEndpoint.ts) - [slackOpenView.ts](./slackOpenView.ts) - [slackPostEphemeralMessage.ts](./slackPostEphemeralMessage.ts) - [slackPostMessage.ts](./slackPostMessage.ts) - [slackPostWaitMessage.ts](./slackPostWaitMessage.ts) - [slackPublishView.ts](./slackPublishView.ts) - [slackPushView.ts](./slackPushView.ts) - [slackRemovePin.ts](./slackRemovePin.ts) - [slackUpdateMessage.ts](./slackUpdateMessage.ts) - [slackUpdateView.ts](./slackUpdateView.ts) - [slackUploadFile.ts](./slackUploadFile.ts)
+ - [README.md](./README.md) - [actionsLoop.ts](./actionsLoop.ts) - [callerSettings.ts](./callerSettings.ts) - [commandsLoop.ts](./commandsLoop.ts) - [index.ts](./index.ts) - [pgPool.ts](./pgPool.ts) - [retrieveEnvironment.ts](./retrieveEnvironment.ts) - [retrieveEvent.ts](./retrieveEvent.ts) - [retrieveModule.ts](./retrieveModule.ts) - [retrieveTeamSettings.ts](./retrieveTeamSettings.ts) - [retrieveUserSettings.ts](./retrieveUserSettings.ts) - [setupContractAndNetwork.ts](./setupContractAndNetwork.ts) - [setupContractNetworkAndSigner.ts](./setupContractNetworkAndSigner.ts) - [setupNetwork.ts](./setupNetwork.ts) - [slackAddPin.ts](./slackAddPin.ts) - [slackDeleteMessage.ts](./slackDeleteMessage.ts) - [slackEndpoint.ts](./slackEndpoint.ts) - [slackOpenView.ts](./slackOpenView.ts) - [slackPostEphemeralMessage.ts](./slackPostEphemeralMessage.ts) - [slackPostMessage.ts](./slackPostMessage.ts) - [slackPostWaitMessage.ts](./slackPostWaitMessage.ts) - [slackPublishView.ts](./slackPublishView.ts) - [slackPushView.ts](./slackPushView.ts) - [slackRemovePin.ts](./slackRemovePin.ts) - [slackUpdateMessage.ts](./slackUpdateMessage.ts) - [slackUpdateView.ts](./slackUpdateView.ts) - [slackUploadFile.ts](./slackUploadFile.ts)
 ## Directory Tree
 [<- Previous](https://github.com/marc-aurele-besner/slack-utility)
 ```
@@ -25,6 +25,7 @@ slackUtils/
    │   callerSettings.ts
    │   commandsLoop.ts
    │   index.ts
+   │   pgPool.ts
    │   retrieveEnvironment.ts
    │   retrieveEvent.ts
    │   retrieveModule.ts

--- a/src/slackUtils/callerSettings.ts
+++ b/src/slackUtils/callerSettings.ts
@@ -11,8 +11,8 @@ const callerSettings = async (
     defaultApiKeys = {} as any,
     defaultSigners = [] as any[]
 ) => {
-    const userSettings: TUserSettings | null = await retrieveUserSettings(user.faunaDbToken, user.id, user.teamId)
-    const teamSettings: TTeamSettings | null = await retrieveTeamSettings(user.faunaDbToken, user.teamId)
+    const userSettings: TUserSettings | null = await retrieveUserSettings(user.dBDetails, user.id, user.teamId)
+    const teamSettings: TTeamSettings | null = await retrieveTeamSettings(user.dBDetails, user.teamId)
     const dbUserSettingFound = userSettings !== null ? true : false
     const dbTeamSettingFound = teamSettings !== null ? true : false
 

--- a/src/slackUtils/pgPool.ts
+++ b/src/slackUtils/pgPool.ts
@@ -1,0 +1,15 @@
+import { Pool } from '@neondatabase/serverless'
+
+const cache = new Map<string, Pool>()
+
+export const getPool = (connectionString: string): Pool => {
+    let pool = cache.get(connectionString)
+    if (!pool) {
+        pool = new Pool({ connectionString })
+        pool.on('error', (err: Error) => console.error('pg pool error', err))
+        cache.set(connectionString, pool)
+    }
+    return pool
+}
+
+export default getPool

--- a/src/slackUtils/retrieveTeamSettings.ts
+++ b/src/slackUtils/retrieveTeamSettings.ts
@@ -1,4 +1,3 @@
-import fauna from 'faunadb-utility'
 import mongoose from 'mongoose'
 
 import { TDBDetails, TTeamSettings } from '../types'
@@ -7,19 +6,6 @@ const retrieveTeamSettings = async (
     dBDetails: TDBDetails,
     slackTeamId: string | undefined
 ): Promise<TTeamSettings | null> => {
-    if (dBDetails.db === 'fauna' && slackTeamId) {
-        try {
-            const getDbTeamSettings = await fauna.queryTermByFaunaIndexes(
-                dBDetails.token,
-                'settings_by_slackTeamUserId',
-                slackTeamId + '_all'
-            )
-            if (JSON.parse(getDbTeamSettings.body).length > 0)
-                return JSON.parse(getDbTeamSettings.body)[0].data.settings
-        } catch (error) {
-            console.log('error', error)
-        }
-    }
     if (dBDetails.db === 'mongo' && slackTeamId) {
         try {
             const db = await mongoose.connect(dBDetails.token)

--- a/src/slackUtils/retrieveTeamSettings.ts
+++ b/src/slackUtils/retrieveTeamSettings.ts
@@ -1,6 +1,7 @@
 import mongoose from 'mongoose'
 
 import { TDBDetails, TTeamSettings } from '../types'
+import getPool from './pgPool'
 
 const retrieveTeamSettings = async (
     dBDetails: TDBDetails,
@@ -13,6 +14,17 @@ const retrieveTeamSettings = async (
                 slackTeamUserId: slackTeamId + '_all'
             })
             if (getDbTeamSettings) return getDbTeamSettings.settings
+        } catch (error) {
+            console.log('error', error)
+        }
+    }
+    if (dBDetails.db === 'postgres' && slackTeamId) {
+        try {
+            const pool = getPool(dBDetails.token)
+            const { rows } = await pool.query('SELECT settings FROM settings WHERE slack_team_user_id = $1 LIMIT 1', [
+                `${slackTeamId}_all`
+            ])
+            if (rows.length > 0) return rows[0].settings as TTeamSettings
         } catch (error) {
             console.log('error', error)
         }

--- a/src/slackUtils/retrieveUserSettings.ts
+++ b/src/slackUtils/retrieveUserSettings.ts
@@ -1,6 +1,7 @@
 import mongoose from 'mongoose'
 
 import { TDBDetails, TUserSettings } from '../types'
+import getPool from './pgPool'
 
 const retrieveUserSettings = async (
     dBDetails: TDBDetails,
@@ -14,6 +15,17 @@ const retrieveUserSettings = async (
                 slackTeamUserId: slackTeamId + '_' + slackUserId
             })
             if (getDbUserSettings) return getDbUserSettings.settings
+        } catch (error) {
+            console.log('error', error)
+        }
+    }
+    if (dBDetails.db === 'postgres' && slackTeamId && slackUserId) {
+        try {
+            const pool = getPool(dBDetails.token)
+            const { rows } = await pool.query('SELECT settings FROM settings WHERE slack_team_user_id = $1 LIMIT 1', [
+                `${slackTeamId}_${slackUserId}`
+            ])
+            if (rows.length > 0) return rows[0].settings as TUserSettings
         } catch (error) {
             console.log('error', error)
         }

--- a/src/slackUtils/retrieveUserSettings.ts
+++ b/src/slackUtils/retrieveUserSettings.ts
@@ -1,4 +1,3 @@
-import fauna from 'faunadb-utility'
 import mongoose from 'mongoose'
 
 import { TDBDetails, TUserSettings } from '../types'
@@ -8,19 +7,6 @@ const retrieveUserSettings = async (
     slackUserId: string | undefined,
     slackTeamId: string | undefined
 ): Promise<TUserSettings | null> => {
-    if (dBDetails.db === 'fauna' && slackUserId) {
-        try {
-            const getDbUserSettings = await fauna.queryTermByFaunaIndexes(
-                dBDetails.token,
-                'settings_by_slackTeamUserId',
-                slackTeamId + '_' + slackUserId
-            )
-            if (JSON.parse(getDbUserSettings.body).length > 0)
-                return JSON.parse(getDbUserSettings.body)[0].data.settings
-        } catch (error) {
-            console.log('error', error)
-        }
-    }
     if (dBDetails.db === 'mongo' && slackTeamId) {
         try {
             const db = await mongoose.connect(dBDetails.token)

--- a/src/slackUtils/slackEndpoint.ts
+++ b/src/slackUtils/slackEndpoint.ts
@@ -12,7 +12,7 @@ const defaultLocalSettings: TLocalAppSettings = {
     useAppForSigner: true,
     allowTeamSettings: true,
     allowUserSettings: true,
-    dbType: 'faunaDB',
+    dbType: 'mongoDB',
     logLevel: 1,
     addDeleteButtons: true,
     addSettingsButton: true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export type TDB = 'fauna' | 'mongo'
+export type TDB = 'mongo' | 'postgres'
 
 export type TDBDetails = {
     db: TDB
@@ -221,7 +221,7 @@ export type TSlackViewResponse = {
     view?: TSlackView | undefined
 }
 
-export type TSupportedDB = 'faunaDB' | 'mongoDB'
+export type TSupportedDB = 'mongoDB' | 'postgresDB'
 
 export type TLocalAppSettings = {
     useDapp: boolean


### PR DESCRIPTION
Replaces faunaDB with Postgres (Neon-compatible) as a supported database backend, alongside the existing MongoDB support.

## Changes

### Remove faunaDB
- Drop `faunadb-utility` dependency
- Drop fauna branch from `retrieveUserSettings` / `retrieveTeamSettings` / `send_call_from_abi` / `settings_save`
- Remove `'fauna'` from `TDB` and `'faunaDB'` from `TSupportedDB`
- Default `dbType` in `slackEndpoint` → `'mongoDB'`
- Fix `callerSettings` to pass `user.dBDetails` (was passing `user.faunaDbToken`)
- Drop `fauna.fauna` / `fauna.faunadb` from `.vscode/extensions.json`

### Add postgres/neonDB
- Add `@neondatabase/serverless` dependency
- New helper `src/slackUtils/pgPool.ts` (per-connection-string `Pool` cache)
- Postgres branches in `retrieveUserSettings` / `retrieveTeamSettings` / `send_call_from_abi` / `settings_save`
- Documented `dbType: 'postgresDB'` and required SQL DDL in `README.md`

### Incidental fixes in `settings_save.ts`
- `.filter(...)` results are now assigned back so collection deletes actually take effect (previously a silent no-op)
- `parsedBody.user.id2` → `parsedBody.user.id` typo (filter was never matching)

## Migration

For consumers currently on `faunaDB`:

1. Provision a Postgres database (Neon recommended for serverless)
2. Apply the schema documented in `README.md`
3. Set `dbType: 'postgresDB'` and pass the connection string as `dBDetails.token`
4. Run a one-time migration of your existing settings/transactions records

MongoDB users are unaffected — the default remains `'mongoDB'`.

## Verification

```bash
npm i --legacy-peer-deps
npm run build  # passes, no fauna strings in dist/
```