### PR TITLE
chore: align minimumReleaseAge between package manager and Renovate at 1 day

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,28 +1,54 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
-  "labels": ["dependencies"],
+  "extends": [
+    "config:recommended"
+  ],
+  "labels": [
+    "dependencies"
+  ],
   "packageRules": [
     {
-      "labels": ["formatter"],
-      "matchPackageNames": ["/prettier/"]
+      "labels": [
+        "formatter"
+      ],
+      "matchPackageNames": [
+        "/prettier/"
+      ]
     },
     {
-      "labels": ["linting"],
-      "matchPackageNames": ["/eslint/"]
+      "labels": [
+        "linting"
+      ],
+      "matchPackageNames": [
+        "/eslint/"
+      ]
     },
     {
-      "labels": ["types"],
-      "matchPackageNames": ["/@types/", "/typescript/"]
+      "labels": [
+        "types"
+      ],
+      "matchPackageNames": [
+        "/@types/",
+        "/typescript/"
+      ]
     },
     {
-      "matchDepTypes": ["optionalDependencies"],
-      "addLabels": ["optional"]
+      "matchDepTypes": [
+        "optionalDependencies"
+      ],
+      "addLabels": [
+        "optional"
+      ]
     },
     {
-      "matchDepTypes": ["minor", "patch", "devDependencies"],
+      "matchDepTypes": [
+        "minor",
+        "patch",
+        "devDependencies"
+      ],
       "automerge": true,
       "automergeType": "pr"
     }
-  ]
+  ],
+  "minimumReleaseAge": "1 day"
 }


### PR DESCRIPTION
## Goal

Set a 1-day minimum release age on the dependency bot (Renovate) and mirror it on the package manager side where a config file already exists. Defense in depth: the bot gates which versions get proposed; the package manager gates which versions install.

## Before

| Side | Value | File |
|------|-------|------|
| Renovate (bot) | no cooldown (extends `config:recommended` or `config:base`, neither sets `minimumReleaseAge`) | `.github/renovate.json` |
| pnpm (PM) | no cooldown (default) | — |
| npm (PM) | no cooldown (default) | — |

## After

| Side | Value | File |
|------|-------|------|
| Renovate (bot) | `minimumReleaseAge: "1 day"` | `.github/renovate.json` |
| pnpm (PM) | — (no `pnpm-workspace.yaml`; not inventing a new file) | — |
| npm (PM) | — (no `.npmrc`; not inventing a new file) | — |

## Why 1 day

User-supplied target for the fleet run. The skill rule: a user-supplied duration applies to every repo in the run but never shortens an existing longer cooldown. No repo in this fleet currently has a longer cooldown, so 1 day applies.

## Files touched

- `.github/renovate.json`

## Excludes

No exclude lists on either side. `internalChecksFilter` is not configured.

## Notes

No lockfile, dependency version, or bot schedule changes. Generated by the `align-minimum-release-age` skill (target = 1 day, fleet mode).
